### PR TITLE
fix: clicking on the dropdown icon opens the dropdown and the page instead of just the dropdown

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -19,6 +19,26 @@
         padding-left: 12px + 20px;
       }
 
+      li > .nav-category{
+        display: flex;
+        align-items: stretch;
+        padding: 0px;
+
+        .dropdown{
+          padding: 5px 10px;
+          margin-right: 5px;
+
+          &:hover{
+            background-color: rgba($color: #fff, $alpha: 0.1);
+          }
+        }
+        
+        a{
+          width: 100%;
+          padding: .25rem .5rem;
+        }
+      }
+
       li > :first-child {
         @extend .btn;
         @extend .btn-sm;
@@ -27,7 +47,7 @@
         font-size: 14px;
         color: $twitch-purple;
         margin: 2px 0;
-
+        
         body.dark-mode & {
           color: $ice;
         }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -180,8 +180,8 @@ $(function() {
     $(".version_release").text(body.tag_name.substring(1));
   });
 
-  $("#Navigation .parent .fas").on("click", function() {
-    $(this).toggleClass("fa-caret-right fa-caret-down");
+  $("#Navigation .parent .dropdown").on("click", function() {
+    $(this).find("i").toggleClass("fa-caret-right fa-caret-down");
     $(this).closest(".parent").children("ul").toggle(250, "linear");
   });
 

--- a/layouts/partials/docs/navigation.html
+++ b/layouts/partials/docs/navigation.html
@@ -6,11 +6,13 @@
         {{- $current := . -}}
         {{- range .Site.Menus.docs -}}
         <li class="{{if .HasChildren }}parent{{end}}{{if and (.Page.IsAncestor $current) .HasChildren }} active-parent{{end}}">
-          <div {{if (eq .URL $current.RelPermalink)}}class="active"{{end}} onClick="window.location.href='{{.URL}}'">
-          {{- if .HasChildren -}}
-          <i class="fas {{if and (.Page.IsAncestor $current) .HasChildren }}fa-caret-down{{ else }}fa-caret-right{{end}}"></i>&nbsp;
-          {{ end }}
-          <a href="{{.URL}}">{{ .Title }}</a>
+          <div class="nav-category{{if (eq .URL $current.RelPermalink)}} active{{end}}">
+            {{- if .HasChildren -}}
+            <div class="dropdown">
+              <i class="fas {{if and (.Page.IsAncestor $current) .HasChildren }}fa-caret-down{{ else }}fa-caret-right{{end}}"></i>
+            </div>
+            {{ end }}
+            <a href="{{.URL}}">{{ .Title }}</a>
           </div>
           {{- if (.HasChildren) -}}
           <ul>


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Removed onclick from divs in documentation sections
* Made it easier to click on the dropdown list by taking into account clicks on the parent div of the icon rather than clicks on the icon itself
* Section anchor tags takes all the available space of the divs in the documentation sections, in order to keep the same behavior as before

### Additional Information

This PR fixes a bug causing the dropdown list icon to open the dropdown list and the page linked to the clicked section, which makes the dropdown list almost unusable. This is due to the presence of an onclick on the div of each section, in which the dropdown is located.
By removing this onclick, the problem was solved, but the dropdown became very difficult to open, because only the arrow icon triggers the dropdown animation. So I decided to enclose the icon in a div taking the full height of the parent div of each section, and add a hover effect to make it look nicer.
Also, removing the onclick made the section openable only by clicking on the a, which doesn't take the whole height and width but only the text of the section. That's why I modified this a to take the full width and height available.